### PR TITLE
fix/032_auto_complete/missing_line--zij

### DIFF
--- a/032_auto_complete.md
+++ b/032_auto_complete.md
@@ -75,6 +75,10 @@ Use this complete the sentence below to "Boban the Bobanish"
 - hit `<c-n>` or `<c-l>` until "Boban the Bobanish" is selected
 - hit escape to go back to normal mode as there's nothing else to type
 
+```
+Boban the
+```
+
 ## Exercise 3
 
 In this directory we have lots of kata files.


### PR DESCRIPTION
Add a missing line for Exercise 2:

In Exercise 2 there's an instruction to `put your cursor on the line`. Such a line doesn't exist.